### PR TITLE
feat(send-signal): dumping memory usage when SIGUSR1

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 clock: node cron.js
+web: node app.js

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
  * @author Léo Unbekandt
  */
 
-// Trap SIGUSR1 to print memory allocation information
+// Trap SIGUSR1 to print memory heap information
 process.on("SIGUSR1", () => {
   const used = process.memoryUsage();
 

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@
 process.on("SIGUSR1", () => {
   const used = process.memoryUsage();
 
-  console.log("Printing memory Usage")
+  console.log("Printing memory usage")
   for (let key in used) {
     console.log(`-  ${key} ${Math.round(used[key] / 1024 / 1024 * 100) / 100} MB`);
   }

--- a/app.js
+++ b/app.js
@@ -2,6 +2,16 @@
  * @author Léo Unbekandt
  */
 
+// Trap SIGUSR1 to print memory allocation information
+process.on("SIGUSR1", () => {
+  const used = process.memoryUsage();
+
+  console.log("Printing memory Usage")
+  for (let key in used) {
+    console.log(`-  ${key} ${Math.round(used[key] / 1024 / 1024 * 100) / 100} MB`);
+  }
+});
+
 var express = require('express')
 var app = express()
 


### PR DESCRIPTION
The purpose is to introduce an example to show the `send-signal` feature to our clients.

This example will be used to in a future article of Scalingo.

This will output:
```
2023-01-10 15:13:22.147625033 +0100 CET [web-1] Printing memory Usage
2023-01-10 15:13:22.147633815 +0100 CET [web-1] - heapTotal 6.7 MB
2023-01-10 15:13:22.147633065 +0100 CET [web-1] - rss 38.89 MB
2023-01-10 15:13:22.147634619 +0100 CET [web-1] - heapUsed 4.59 MB
2023-01-10 15:13:22.147635164 +0100 CET [web-1] - external 1.39 MB
2023-01-10 15:13:22.147635509 +0100 CET [web-1] - arrayBuffers 0.03 MB 
```